### PR TITLE
Fix issue with Title Screen Mobs

### DIFF
--- a/common/src/main/java/net/venturecraft/gliders/client/layer/PlayerGliderLayer.java
+++ b/common/src/main/java/net/venturecraft/gliders/client/layer/PlayerGliderLayer.java
@@ -46,7 +46,7 @@ public class PlayerGliderLayer<T extends LivingEntity, M extends HumanoidModel<T
 
     @Override
     public void render(PoseStack poseStack, MultiBufferSource bufferSource, int p_117351_, T living, float p_117353_, float p_117354_, float p_117355_, float p_117356_, float p_117357_, float p_117358_) {
-        if (living.isInvisibleTo(Minecraft.getInstance().player)) return;
+        if (Minecraft.getInstance().player == null || living.isInvisibleTo(Minecraft.getInstance().player)) return;
 
         ItemStack stack = CuriosTrinketsUtil.getInstance().getFirstFoundGlider(living);
 


### PR DESCRIPTION
Add a basic null check to `PlayerGliderLayer` that should fix the issue with Title Screen Mobs (#117)